### PR TITLE
Fix cannot read property 'context' of undefined on Android with {N} 8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "scripts": {
         "setup": "ts-patch install",
-"prepare": "npm run setup",
+        "prepare": "npm run setup",
         "tsc": "cp src/extendedinfo.d.ts plugin && tsc -skipLibCheck -d",
         "build": "rm -f .tsbuildinfo && npm run tsc",
         "publish": "npm run setup && npm run build && lerna publish --create-release=github --force-publish",

--- a/src/extendedinfo.android.ts
+++ b/src/extendedinfo.android.ts
@@ -1,4 +1,5 @@
-import { android as androidApp, launchEvent, off, on } from '@nativescript/core/application';
+import { Utils } from '@nativescript/core';
+import { launchEvent, on } from '@nativescript/core/application';
 
 let isSimulatorCache: boolean;
 export function isSimulator() {
@@ -20,7 +21,7 @@ export function isSimulator() {
 let appContext: android.content.Context;
 function getAppContextSync(): android.content.Context {
     if (!appContext) {
-        appContext = androidApp.context;
+        appContext = Utils.android.getApplicationContext();
     }
     return appContext;
 }

--- a/src/extendedinfo.android.ts
+++ b/src/extendedinfo.android.ts
@@ -11,7 +11,6 @@ export function isSimulator() {
             Build.MODEL.indexOf('Emulator') !== -1 ||
             Build.MODEL.indexOf('Android SDK built for x86') !== -1 ||
             Build.MANUFACTURER.indexOf('Genymotion') !== -1 ||
-            Build.MANUFACTURER.indexOf('Genymotion') !== -1 ||
             (Build.BRAND.startsWith('generic') && Build.DEVICE.startsWith('generic')) ||
             Build.PRODUCT.indexOf('sdk') !== -1;
     }


### PR DESCRIPTION
Hi there!

I've updated one project to NativeScript 8.2 and I had this error after that:

```
TypeError: Cannot read property 'context' of undefined
    at getAppContextSync (file: app/webpack:/my-app/node_modules/@nativescript-community/extendedinfo/extendedinfo.android.js:22:21)
    at file: app/webpack:/my-app/node_modules/@nativescript-community/extendedinfo/extendedinfo.android.js:28:0
    at new Promise (<anonymous>)
    at getAppContext (file: app/webpack:/my-app/node_modules/@nativescript-community/extendedinfo/extendedinfo.android.js:27:0)
    at getPackageInfo (file: app/webpack:/my-app/node_modules/@nativescript-community/extendedinfo/extendedinfo.android.js:51:0)
    at getVersionName (file: app/webpack:/my-app/node_modules/@nativescript-community/extendedinfo/extendedinfo.android.js:96:0)
    at Module../app/main.js (file: app/webpack:/my-app/app/main.js:36:27)
    at __webpack_require__ (file: app/webpack:/my-app/webpack/bootstrap:24:0)
    at __webpack_exec__ (file:///data/data/com.myapp/files/app/bundle.js:35026:39)
    at file:///data/data/com.myapp/files/app/bundle.js:35027:221
```

So here's the fix (I also noticed that `androidApp.context` is deprecated so I replaced it with the suggestion). There are also two other small fixes commited, I just couldn't help it 😅

I've tested it only with NativeScript 8.2 so I don't know if it would break anything. 